### PR TITLE
Fix 2 bugs in Test::HTTP::MockServer

### DIFF
--- a/lib/Test/HTTP/MockServer.pm
+++ b/lib/Test/HTTP/MockServer.pm
@@ -11,7 +11,7 @@ our $VERSION = '0.0.1';
 sub new {
     my ($class) = @_;
     $class = ref $class || $class;
-    return bless {}, $class;
+    return bless {parent_pid => $$}, $class;
 }
 
 sub bind_mock_server {
@@ -165,7 +165,7 @@ sub DESTROY {
     my $self = shift;
     eval {
         $self->stop_mock_server
-          if $self->{mock_server_pid};
+          if $self->{mock_server_pid} && $$ == $self->{parent_pid};
     };
 }
 

--- a/lib/Test/HTTP/MockServer.pm
+++ b/lib/Test/HTTP/MockServer.pm
@@ -135,6 +135,8 @@ sub start_mock_server {
     my $self = shift;
     my $rp = shift or die "No request processor";
 
+    $self->bind_mock_server;
+
     die "There is already a mock server running"
       if $self->{mock_server_pid};
 
@@ -319,5 +321,3 @@ See the License for the specific language governing permissions and
 limitations under the License.
 
 =cut
-
-

--- a/lib/Test/HTTP/MockServer.pm
+++ b/lib/Test/HTTP/MockServer.pm
@@ -6,7 +6,7 @@ use HTTP::Response;
 use IO::Handle;
 use Socket;
 
-our $VERSION = '0.0.1';
+our $VERSION = '0.0.2';
 
 sub new {
     my ($class) = @_;

--- a/t/01-basic-request.t
+++ b/t/01-basic-request.t
@@ -5,8 +5,6 @@ use IO::Handle;
 use_ok('Test::HTTP::MockServer');
 
 my $server = Test::HTTP::MockServer->new();
-my $url = $server->url_base();
-my $ua = LWP::UserAgent->new;
 
 STDOUT->autoflush(1);
 STDERR->autoflush(1);
@@ -18,6 +16,9 @@ my $handle_request_phase1 = sub {
 };
 
 $server->start_mock_server($handle_request_phase1);
+
+my $url = $server->url_base();
+my $ua = LWP::UserAgent->new;
 
 my $res = $ua->get($url);
 is($res->code, 200, 'default response code');
@@ -81,4 +82,3 @@ distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
-

--- a/t/03-fork-resistant.t
+++ b/t/03-fork-resistant.t
@@ -1,0 +1,36 @@
+use Test::More;
+use LWP::UserAgent;
+use IO::Handle;
+
+use_ok('Test::HTTP::MockServer');
+
+my $server = Test::HTTP::MockServer->new();
+$server->start_mock_server(sub { return });
+
+if (!fork) {
+  exit 0;
+}
+
+my $ua = LWP::UserAgent->new;
+my $res = $ua->get($server->url_base());
+is($res->code, 200, 'default response code');
+
+$server->stop_mock_server();
+
+done_testing();
+
+__END__
+
+Copyright 2016 Bloomberg Finance L.P.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
**Describe your changes**

-   Calls `bind_mock_server` automatically in `start_mock_server`
    -   This is the behavior that is already documented in the module POD.
    -   Before this change, this happened only when `base_url` was called.
-   Do not close the server socket from a forked process
    -   This is a problem when using other forking libraries as a forked mock server object will close the main socket from a child process.
    -   Now we test for the PID of the initial process before closing the socket.

**Testing performed**

- Modified `t/01-basic-request.t` to exercise the automatic call to `bind_mock_server`.
- Added `t/03-fork-resistant.t` to test the behavior of the library in the presence of a `fork`.

Both tests fails without their associated code change.
